### PR TITLE
feat: add link to uptime dashboard

### DIFF
--- a/internal/templates/pages/cloud.templ
+++ b/internal/templates/pages/cloud.templ
@@ -38,6 +38,34 @@ templ Cloud(services []models.CloudService, isLoggedIn bool) {
 						@cloudServiceCard(svc)
 					}
 				</div>
+				<div class="mt-16">
+					<h2 class="text-2xl font-bold text-gray-300 mb-4 flex items-center gap-3">
+						<span class="text-accent-cyan">{ "//" }</span> System Health
+					</h2>
+					<p class="text-gray-500 mb-8">
+						Check the live status of all RobsCloud services. Outages and maintenance windows are reported here in real time.
+					</p>
+					<a
+						href="https://uptime.robswebhub.net/status/friends"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="group card block no-underline"
+					>
+						<div class="flex items-center gap-4 md:gap-6">
+							<div class="flex-shrink-0 w-14 h-14 md:w-16 md:h-16 rounded-lg bg-dark-700 p-3 group-hover:bg-dark-700/80 transition-colors flex items-center justify-center">
+								<svg class="w-8 h-8 text-accent-green" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12h4l3-9 4 18 3-9h4"></path>
+								</svg>
+							</div>
+							<div class="flex-1 min-w-0">
+								<h3 class="font-bold text-lg text-gray-100 group-hover:text-accent-cyan transition-colors">
+									Service Status Dashboard
+								</h3>
+								<p class="text-gray-500 text-sm md:text-base">View real-time uptime and health monitoring for all RobsCloud services</p>
+							</div>
+						</div>
+					</a>
+				</div>
 			</div>
 		</main>
 	}
@@ -58,14 +86,7 @@ templ cloudServiceCard(svc models.CloudService) {
 				</h3>
 				<p class="text-gray-500 text-sm md:text-base">{ svc.Description }</p>
 			</div>
-			<div class="flex-shrink-0 hidden sm:block">
-				<span class="btn">
-					Launch
-					<svg class="w-4 h-4 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
-					</svg>
-				</span>
-			</div>
+
 		</div>
 	</a>
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added System Health section to the Cloud page with a Service Status Dashboard card providing external status information links.

* **UI Changes**
  * Removed action buttons from cloud service cards for a streamlined interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->